### PR TITLE
Add the ability to control the backlight brightness

### DIFF
--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -47,6 +47,7 @@ namespace pimoroni {
     uint lcd_dot_clk = 22;
 
     static const uint32_t SPI_BAUD = 8'000'000;
+    static const uint32_t BACKLIGHT_PWM_TOP = 6200;
 
   public:
     // Parallel init

--- a/modules/c/presto/presto.c
+++ b/modules/c/presto/presto.c
@@ -5,12 +5,14 @@
 
 MP_DEFINE_CONST_FUN_OBJ_1(Presto___del___obj, Presto___del__);
 MP_DEFINE_CONST_FUN_OBJ_2(Presto_update_obj, Presto_update);
+MP_DEFINE_CONST_FUN_OBJ_2(Presto_set_backlight_obj, Presto_set_backlight);
 
 /***** Binding of Methods *****/
 
 static const mp_rom_map_elem_t Presto_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&Presto___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&Presto_update_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_backlight), MP_ROM_PTR(&Presto_set_backlight_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(WIDTH) },
     { MP_ROM_QSTR(MP_QSTR_HEIGHT), MP_ROM_INT(HEIGHT) },

--- a/modules/c/presto/presto.cpp
+++ b/modules/c/presto/presto.cpp
@@ -159,6 +159,18 @@ extern mp_obj_t Presto_update(mp_obj_t self_in, mp_obj_t graphics_in) {
     return mp_const_none;
 }
 
+mp_obj_t Presto_set_backlight(mp_obj_t self_in, mp_obj_t brightness) {
+    _Presto_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Presto_obj_t);
+
+    float b = mp_obj_get_float(brightness);
+
+    if(b < 0 || b > 1.0f) mp_raise_ValueError("brightness out of range. Expected 0.0 to 1.0");
+
+    self->presto->set_backlight((uint8_t)(b * 255.0f));
+
+    return mp_const_none;
+}
+
 mp_obj_t Presto___del__(mp_obj_t self_in) {
     (void)self_in;
     //_Presto_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Presto_obj_t);

--- a/modules/c/presto/presto.h
+++ b/modules/c/presto/presto.h
@@ -2,7 +2,7 @@
 #include "py/runtime.h"
 
 /***** Constants *****/
-static const uint BACKLIGHT = 38;
+static const uint BACKLIGHT = 45;
 
 static const int WIDTH = 240;
 static const int HEIGHT = 240;
@@ -19,4 +19,5 @@ extern const mp_obj_type_t Presto_type;
 extern mp_obj_t Presto_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t Presto_update(mp_obj_t self_in, mp_obj_t graphics_in);
 extern mp_int_t Presto_get_framebuffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags);
+extern mp_obj_t Presto_set_backlight(mp_obj_t self_in, mp_obj_t brightness);
 extern mp_obj_t Presto___del__(mp_obj_t self_in);


### PR DESCRIPTION
I'm not 100% sure whether this backlight pin is intended to be PWM'd, given the way it cuts in fairly bright already and then tops out around 13-14% duty cycle, but this does give some control over brightness.