### PR TITLE
Drivers: Bit reverse in PIO, use new RGB565 pinout.

### DIFF
--- a/drivers/st7701/st7701_parallel.pio
+++ b/drivers/st7701/st7701_parallel.pio
@@ -1,29 +1,32 @@
-; Output 18 bit parallel RGB666 data every clock
+; Output 16 bit parallel RGB565 data every clock
 ; Wait for irq 4 from the timing SM between each row
 ; Side-set is data enable
 
 .program st7701_parallel
 .side_set 1
 
+  mov pins, null side 0
+  wait 1 irq 4   side 0
 .wrap_target
-  mov x, y      side 0  ; y needs to be set to width-1 at init time
-  wait 1 irq 4  side 0  ; wait for the irq from the timing SM
-  nop side 1 [1]        ; This reduces the offset of the image on the screen from 4 to 3 pixels
-loop:                   ; Not really sure why the offset is there, enable should only have 5ns setup
-  out pins, 16  side 1
-  jmp x-- loop  side 1
-  mov pins, null side 1
+  out isr,  32    side 1
+  mov pins, ::isr side 1
+  in null, 16     side 1
+  mov pins, ::isr side 1  
 .wrap
+
+; Output 16 bit parallel RGB565 data every other clock
 
 .program st7701_parallel_double
 .side_set 1
 
 .wrap_target
-  mov x, y      side 0  ; y needs to be set to width-1 at init time
+  mov x, y      side 0  ; y needs to be set to (width/2)-1 at init time
   wait 1 irq 4  side 0  ; wait for the irq from the timing SM
-  nop side 1 [1]        ; This reduces the offset of the image on the screen from 4 to 3 pixels
-loop:                   ; Not really sure why the offset is there, enable should only have 5ns setup
-  out pins, 16  side 1 [2]
+loop:
+  out isr, 32 side 1     
+  mov pins, ::isr side 1 [1]
+  in null, 16 side 1     [1]
+  mov pins, ::isr side 1 [1]
   jmp x-- loop  side 1
   mov pins, null side 1
 .wrap

--- a/drivers/st7701/st7701_timing.pio
+++ b/drivers/st7701/st7701_timing.pio
@@ -3,11 +3,12 @@
 ; 30: HSync
 ; 29-16: Delay duration in pixel clocks, total loop duration is delay + 3
 ; 15-0:  Instruction to run after delay, sensible options are:
-;        nop   : 0xa042 ; Do nothing
-;        irq n : 0xc00n ; Signal to CPU or a data PIO
+;        nop   : 0xb042 ; Do nothing
+;        irq n : 0xd00n ; Signal to CPU or a data PIO
 ; Side set is data clock, which runs continuously
 .program st7701_timing
 .side_set 1
+.origin 0
 
 .wrap_target
   out pins, 2         side 0    ; Set VS & HS
@@ -16,5 +17,4 @@ sync_loop:
   nop                 side 0
   jmp x--, sync_loop  side 1
   out exec, 16        side 0
-  nop                 side 1
 .wrap

--- a/modules/c/presto/presto.cpp
+++ b/modules/c/presto/presto.cpp
@@ -146,23 +146,9 @@ mp_int_t Presto_get_framebuffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_
     return 0;
 }
 
-static inline int32_t reverse(uint32_t x) {
-    x = ((x >>  1) & 0x55555555u) | ((x & 0x55555555u) <<  1);
-    x = ((x >>  2) & 0x33333333u) | ((x & 0x33333333u) <<  2);
-    x = ((x >>  4) & 0x0f0f0f0fu) | ((x & 0x0f0f0f0fu) <<  4);
-    x = ((x << 1) & 0xffc0ffc0) | (x & 0x003f003f); // drop the high B bit and merge
-    return x;
-}
-
 extern mp_obj_t Presto_update(mp_obj_t self_in, mp_obj_t graphics_in) {
     _Presto_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Presto_obj_t);
     ModPicoGraphics_obj_t *picographics = MP_OBJ_TO_PTR2(graphics_in, ModPicoGraphics_obj_t);
-
-    uint32_t *p = (uint32_t *)self->next_fb;
-    for(uint32_t i = 0; i < 28800; i++) {
-        *p = reverse(*p);
-        p++;
-    }
 
     self->presto->set_framebuffer(self->next_fb);
     std::swap(self->next_fb, self->curr_fb);


### PR DESCRIPTION
This tweaks the pinout to match the new hardware revision, and also offloads the work of reversing the pixel bit order to the PIO.

It also fixes a timing bug I noticed while debugging the bit reversal.