### PR TITLE
Fix wifi setup after display init

### DIFF
--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -205,21 +205,15 @@ void ST7701::init_framebuffer() {
     framebuffer += 0x2000000;
 }
 
-  ST7701::ST7701(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, uint16_t* framebuffer, uint16_t* linebuffer,
+  ST7701::ST7701(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, uint16_t* framebuffer,
       uint d0, uint hsync, uint vsync, uint lcd_de, uint lcd_dot_clk) :
             DisplayDriver(width, height, rotation),
             spi(control_pins.spi),
             spi_cs(control_pins.cs), spi_sck(control_pins.sck), spi_dat(control_pins.mosi), lcd_bl(control_pins.bl),
             d0(d0), hsync(hsync), vsync(vsync), lcd_de(lcd_de), lcd_dot_clk(lcd_dot_clk),
-            framebuffer(framebuffer),
-            line_buffer(linebuffer)
+            framebuffer(framebuffer)
   {
       st7701_inst = this;
-
-      // Allocate line buffers only if none supplied and frame buffer is not in internal RAM.
-      if(!line_buffer && (intptr_t)framebuffer < 0x20000000) {
-        line_buffer = (uint16_t*)malloc(NUM_LINE_BUFFERS * width * sizeof(line_buffer[0]));
-      }
   }
 
   void ST7701::init() {
@@ -323,7 +317,7 @@ void ST7701::init_framebuffer() {
       channel_config_set_dreq(&config, pio_get_dreq(st_pio, parallel_sm, true));
       channel_config_set_bswap(&config, true);
       channel_config_set_chain_to(&config, st_dma2);
-      dma_channel_configure(st_dma, &config, &st_pio->txf[parallel_sm], line_buffer, width >> 1, false);
+      dma_channel_configure(st_dma, &config, &st_pio->txf[parallel_sm], nullptr, width >> 1, false);
 
       config = dma_channel_get_default_config(st_dma2);
       channel_config_set_transfer_data_size(&config, DMA_SIZE_32);

--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -221,7 +221,7 @@ void ST7701::init_framebuffer() {
   
       init_framebuffer();
 
-      st_pio = pio2;
+      st_pio = pio1;
       parallel_sm = pio_claim_unused_sm(st_pio, true);
 
       if      (width == 480) parallel_offset = pio_add_program(st_pio, &st7701_parallel_program);
@@ -313,7 +313,6 @@ void ST7701::init_framebuffer() {
 
       dma_channel_config config = dma_channel_get_default_config(st_dma);
       channel_config_set_transfer_data_size(&config, DMA_SIZE_32);
-      channel_config_set_high_priority(&config, true);
       channel_config_set_dreq(&config, pio_get_dreq(st_pio, parallel_sm, true));
       channel_config_set_bswap(&config, true);
       channel_config_set_chain_to(&config, st_dma2);
@@ -323,8 +322,6 @@ void ST7701::init_framebuffer() {
       channel_config_set_transfer_data_size(&config, DMA_SIZE_32);
       channel_config_set_read_increment(&config, false);
       dma_channel_configure(st_dma2, &config, &dma_hw->ch[st_dma].al3_read_addr_trig, &next_line_addr, 1, false);
-
-      hw_set_bits(&bus_ctrl_hw->priority, (BUSCTRL_BUS_PRIORITY_PROC1_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS | BUSCTRL_BUS_PRIORITY_DMA_W_BITS));
 
       printf("Begin SPI setup\n");
 

--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -50,7 +50,7 @@ namespace pimoroni {
 
   public:
     // Parallel init
-    ST7701(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, uint16_t* framebuffer, uint16_t* linebuffer,
+    ST7701(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, uint16_t* framebuffer,
       uint d0=1, uint hsync=19, uint vsync=20, uint lcd_de = 21, uint lcd_dot_clk = 22);
 
     void init();
@@ -87,7 +87,6 @@ namespace pimoroni {
     uint16_t* framebuffer;
     uint16_t* next_framebuffer = nullptr;
 
-    uint16_t* line_buffer;
     uint16_t* next_line_addr;
     int display_row = 0;
     int row_shift = 0;

--- a/modules/c/presto/presto.cpp
+++ b/modules/c/presto/presto.cpp
@@ -99,7 +99,7 @@ mp_obj_t Presto_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     presto_debug("m_new_class(ST7701...\n");
     ST7701 *presto = m_new_class(ST7701, WIDTH, HEIGHT, ROTATE_0,
         SPIPins{spi1, LCD_CS, LCD_CLK, LCD_DAT, PIN_UNUSED, LCD_DC, BACKLIGHT},
-        self->next_fb, nullptr,
+        self->next_fb,
         LCD_D0);
 
     self->presto = presto;


### PR DESCRIPTION
The wifi and siaply were both using PIO2 which was causing conflicts.  I've switched ST7701 to use PIO1.

Additionally, the high priority DMA transfer to the display was causing the CYW43 driver to fail to load if the display was already initialized.  Now we're using a RAM buffer and queueing the whole frame to be transferred this seems to be much less time critical, so I've removed the extra priority bits.

This also picks up a little bit of tidy up, removing the now unused line buffer.