### PR TITLE
Full resolution display support

### DIFF
--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -47,6 +47,7 @@ namespace pimoroni {
     uint lcd_dot_clk = 22;
 
     static const uint32_t SPI_BAUD = 8'000'000;
+    static const uint32_t BACKLIGHT_PWM_TOP = 6200;
 
   public:
     // Parallel init

--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -57,6 +57,7 @@ namespace pimoroni {
     void init();
     void cleanup() override;
     void update(PicoGraphics *graphics) override;
+    void partial_update(PicoGraphics *display, Rect region) override;
     void set_backlight(uint8_t brightness) override;
 
     void set_framebuffer(uint16_t* next_fb) {
@@ -78,7 +79,6 @@ namespace pimoroni {
 
     void start_line_xfer();
     void start_frame_xfer();
-    void init_framebuffer();
 
     // Timing status
     uint16_t timing_row = 0;

--- a/drivers/st7701/st7701_parallel.pio
+++ b/drivers/st7701/st7701_parallel.pio
@@ -1,22 +1,8 @@
-; Output 16 bit parallel RGB565 data every clock
+; Output 16 bit parallel, bit reversed, RGB565 data every 4th clock
 ; Wait for irq 4 from the timing SM between each row
 ; Side-set is data enable
 
 .program st7701_parallel
-.side_set 1
-
-  mov pins, null side 0
-  wait 1 irq 4   side 0
-.wrap_target
-  out isr,  32    side 1
-  mov pins, ::isr side 1
-  in null, 16     side 1
-  mov pins, ::isr side 1  
-.wrap
-
-; Output 16 bit parallel RGB565 data every other clock
-
-.program st7701_parallel_double
 .side_set 1
 
 .wrap_target

--- a/examples/vector_clock_full.py
+++ b/examples/vector_clock_full.py
@@ -1,0 +1,138 @@
+import presto
+
+import time
+import gc
+
+from picographics import PicoGraphics, DISPLAY_PRESTO_FULL_RES
+from picovector import PicoVector, Polygon, RegularPolygon, Rectangle, ANTIALIAS_X4, ANTIALIAS_X16
+
+machine.freq(264000000)
+
+presto = presto.Presto(full_res=True)
+
+display = PicoGraphics(DISPLAY_PRESTO_FULL_RES)
+
+vector = PicoVector(display)
+vector.set_antialiasing(ANTIALIAS_X4)
+
+RED = display.create_pen(200, 0, 0)
+BLACK = display.create_pen(0, 0, 0)
+GREY = display.create_pen(200, 200, 200)
+WHITE = display.create_pen(255, 255, 255)
+
+"""
+# Redefine colours for a Blue clock
+RED = display.create_pen(200, 0, 0)
+BLACK = display.create_pen(135, 159, 169)
+GREY = display.create_pen(10, 40, 50)
+WHITE = display.create_pen(14, 60, 76)
+"""
+
+WIDTH, HEIGHT = display.get_bounds()
+
+hub = RegularPolygon(int(WIDTH / 2), int(HEIGHT / 2), 24, 5)
+
+face = RegularPolygon(int(WIDTH / 2), int(HEIGHT / 2), 48, int(HEIGHT / 2))
+
+print(time.localtime())
+
+last_second = None
+
+def fade_in():
+    for j in range(101):
+        presto.set_backlight(j*0.01)
+        time.sleep_us(700)
+        
+def fade_out():
+    for j in range(101):
+        presto.set_backlight(1 - j*0.01)
+        time.sleep_us(700)
+
+while True:
+    t_start = time.ticks_ms()
+    year, month, day, hour, minute, second, _, _ = time.localtime()
+
+    if last_second == second:
+        time.sleep_ms(10)
+        continue
+
+    last_second = second
+
+    fade_out()
+
+    display.set_pen(0)
+    display.clear()
+
+    display.set_pen(BLACK)
+    display.circle(int(WIDTH / 2), int(HEIGHT / 2), int(HEIGHT / 2))
+    display.set_pen(WHITE)
+    display.circle(int(WIDTH / 2), int(HEIGHT / 2), int(HEIGHT / 2) - 4)
+
+    display.set_pen(GREY)
+
+    for a in range(60):
+        tick_mark = Rectangle(int(WIDTH / 2) - 3, 10, 6, int(HEIGHT / 48))
+        vector.rotate(tick_mark, 360 / 60.0 * a, int(WIDTH / 2), int(HEIGHT / 2))
+        vector.translate(tick_mark, 0, 2)
+        vector.draw(tick_mark)
+
+    for a in range(12):
+        hour_mark = Rectangle(int(WIDTH / 2) - 5, 10, 10, int(HEIGHT / 10))
+        vector.rotate(hour_mark, 360 / 12.0 * a, int(WIDTH / 2), int(HEIGHT / 2))
+        vector.translate(hour_mark, 0, 2)
+        vector.draw(hour_mark)
+
+    angle_second = second * 6
+    second_hand_length = int(HEIGHT / 2) - int(HEIGHT / 8)
+    second_hand = Polygon((-2, -second_hand_length), (-2, int(HEIGHT / 8)), (2, int(HEIGHT / 8)), (2, -second_hand_length))
+    vector.rotate(second_hand, angle_second, 0, 0)
+    vector.translate(second_hand, int(WIDTH / 2), int(HEIGHT / 2) + 5)
+
+    angle_minute = minute * 6
+    angle_minute += second / 10.0
+    minute_hand_length = int(HEIGHT / 2) - int(HEIGHT / 24)
+    minute_hand = Polygon((-5, -minute_hand_length), (-10, int(HEIGHT / 16)), (10, int(HEIGHT / 16)), (5, -minute_hand_length))
+    vector.rotate(minute_hand, angle_minute, 0, 0)
+    vector.translate(minute_hand, int(WIDTH / 2), int(HEIGHT / 2) + 5)
+
+    angle_hour = (hour % 12) * 30
+    angle_hour += minute / 2
+    hour_hand_length = int(HEIGHT / 2) - int(HEIGHT / 8)
+    hour_hand = Polygon((-5, -hour_hand_length), (-10, int(HEIGHT / 16)), (10, int(HEIGHT / 16)), (5, -hour_hand_length))
+    vector.rotate(hour_hand, angle_hour, 0, 0)
+    vector.translate(hour_hand, int(WIDTH / 2), int(HEIGHT / 2) + 5)
+
+    display.set_pen(GREY)
+
+    vector.draw(minute_hand)
+    vector.draw(hour_hand)
+    vector.draw(second_hand)
+
+    display.set_pen(BLACK)
+
+    for a in range(60):
+        tick_mark = Rectangle(int(WIDTH / 2) - 3, 10, 6, int(HEIGHT / 48))
+        vector.rotate(tick_mark, 360 / 60.0 * a, int(WIDTH / 2), int(HEIGHT / 2))
+        vector.draw(tick_mark)
+
+    for a in range(12):
+        hour_mark = Rectangle(int(WIDTH / 2) - 5, 10, 10, int(HEIGHT / 10))
+        vector.rotate(hour_mark, 360 / 12.0 * a, int(WIDTH / 2), int(HEIGHT / 2))
+        vector.draw(hour_mark)
+
+    vector.translate(minute_hand, 0, -5)
+    vector.translate(hour_hand, 0, -5)
+    vector.draw(minute_hand)
+    vector.draw(hour_hand)
+
+    display.set_pen(RED)
+    vector.translate(second_hand, 0, -5)
+    vector.draw(second_hand)
+    vector.draw(hub)
+
+    presto.update(display)
+    fade_in()
+    gc.collect()
+
+    t_end = time.ticks_ms()
+    print(f"Took {t_end - t_start}ms")

--- a/modules/c/presto/presto.c
+++ b/modules/c/presto/presto.c
@@ -14,8 +14,10 @@ static const mp_rom_map_elem_t Presto_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&Presto_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_backlight), MP_ROM_PTR(&Presto_set_backlight_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(WIDTH) },
-    { MP_ROM_QSTR(MP_QSTR_HEIGHT), MP_ROM_INT(HEIGHT) },
+    { MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(WIDTH/2) },
+    { MP_ROM_QSTR(MP_QSTR_HEIGHT), MP_ROM_INT(HEIGHT/2) },
+    { MP_ROM_QSTR(MP_QSTR_FULL_WIDTH), MP_ROM_INT(WIDTH) },
+    { MP_ROM_QSTR(MP_QSTR_FULL_HEIGHT), MP_ROM_INT(HEIGHT) },
 };
 
 static MP_DEFINE_CONST_DICT(Presto_locals_dict, Presto_locals_dict_table);

--- a/modules/c/presto/presto.c
+++ b/modules/c/presto/presto.c
@@ -5,6 +5,7 @@
 
 MP_DEFINE_CONST_FUN_OBJ_1(Presto___del___obj, Presto___del__);
 MP_DEFINE_CONST_FUN_OBJ_2(Presto_update_obj, Presto_update);
+MP_DEFINE_CONST_FUN_OBJ_KW(Presto_partial_update_obj, 5, Presto_partial_update);
 MP_DEFINE_CONST_FUN_OBJ_2(Presto_set_backlight_obj, Presto_set_backlight);
 
 /***** Binding of Methods *****/
@@ -12,6 +13,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(Presto_set_backlight_obj, Presto_set_backlight);
 static const mp_rom_map_elem_t Presto_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&Presto___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&Presto_update_obj) },
+    { MP_ROM_QSTR(MP_QSTR_partial_update), MP_ROM_PTR(&Presto_partial_update_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_backlight), MP_ROM_PTR(&Presto_set_backlight_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(WIDTH/2) },

--- a/modules/c/presto/presto.c
+++ b/modules/c/presto/presto.c
@@ -5,12 +5,14 @@
 
 MP_DEFINE_CONST_FUN_OBJ_1(Presto___del___obj, Presto___del__);
 MP_DEFINE_CONST_FUN_OBJ_2(Presto_update_obj, Presto_update);
+MP_DEFINE_CONST_FUN_OBJ_2(Presto_set_backlight_obj, Presto_set_backlight);
 
 /***** Binding of Methods *****/
 
 static const mp_rom_map_elem_t Presto_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&Presto___del___obj) },
     { MP_ROM_QSTR(MP_QSTR_update), MP_ROM_PTR(&Presto_update_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_backlight), MP_ROM_PTR(&Presto_set_backlight_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(WIDTH) },
     { MP_ROM_QSTR(MP_QSTR_HEIGHT), MP_ROM_INT(HEIGHT) },

--- a/modules/c/presto/presto.cpp
+++ b/modules/c/presto/presto.cpp
@@ -159,6 +159,18 @@ extern mp_obj_t Presto_update(mp_obj_t self_in, mp_obj_t graphics_in) {
     return mp_const_none;
 }
 
+mp_obj_t Presto_set_backlight(mp_obj_t self_in, mp_obj_t brightness) {
+    _Presto_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Presto_obj_t);
+
+    float b = mp_obj_get_float(brightness);
+
+    if(b < 0 || b > 1.0f) mp_raise_ValueError("brightness out of range. Expected 0.0 to 1.0");
+
+    self->presto->set_backlight((uint8_t)(b * 255.0f));
+
+    return mp_const_none;
+}
+
 mp_obj_t Presto___del__(mp_obj_t self_in) {
     (void)self_in;
     //_Presto_obj_t *self = MP_OBJ_TO_PTR2(self_in, _Presto_obj_t);

--- a/modules/c/presto/presto.h
+++ b/modules/c/presto/presto.h
@@ -2,7 +2,7 @@
 #include "py/runtime.h"
 
 /***** Constants *****/
-static const uint BACKLIGHT = 38;
+static const uint BACKLIGHT = 45;
 
 static const int WIDTH = 240;
 static const int HEIGHT = 240;
@@ -19,4 +19,5 @@ extern const mp_obj_type_t Presto_type;
 extern mp_obj_t Presto_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t Presto_update(mp_obj_t self_in, mp_obj_t graphics_in);
 extern mp_int_t Presto_get_framebuffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags);
+extern mp_obj_t Presto_set_backlight(mp_obj_t self_in, mp_obj_t brightness);
 extern mp_obj_t Presto___del__(mp_obj_t self_in);

--- a/modules/c/presto/presto.h
+++ b/modules/c/presto/presto.h
@@ -4,8 +4,8 @@
 /***** Constants *****/
 static const uint BACKLIGHT = 45;
 
-static const int WIDTH = 240;
-static const int HEIGHT = 240;
+static const int WIDTH = 480;
+static const int HEIGHT = 480;
 static const uint LCD_CLK = 26;
 static const uint LCD_CS = 28;
 static const uint LCD_DAT = 27;

--- a/modules/c/presto/presto.h
+++ b/modules/c/presto/presto.h
@@ -18,6 +18,7 @@ extern const mp_obj_type_t Presto_type;
 /***** Extern of Class Methods *****/
 extern mp_obj_t Presto_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args);
 extern mp_obj_t Presto_update(mp_obj_t self_in, mp_obj_t graphics_in);
+extern mp_obj_t Presto_partial_update(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_int_t Presto_get_framebuffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags);
 extern mp_obj_t Presto_set_backlight(mp_obj_t self_in, mp_obj_t brightness);
 extern mp_obj_t Presto___del__(mp_obj_t self_in);

--- a/presto/mpconfigboard.cmake
+++ b/presto/mpconfigboard.cmake
@@ -13,6 +13,9 @@ set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)
 # there needs to be some RAM reserved for the C heap
 set(MICROPY_C_HEAP_SIZE 4096)
 
+# Enable PSRAM
+set(MICROPY_HW_ENABLE_PSRAM ON)
+
 # Links micropy_lib_lwip and sets MICROPY_PY_LWIP = 1
 # Picked up and expanded upon in mpconfigboard.h
 set(MICROPY_PY_LWIP ON)

--- a/presto/mpconfigboard.h
+++ b/presto/mpconfigboard.h
@@ -30,7 +30,6 @@ int mp_hal_is_pin_reserved(int n);
 
 // Alias the chip select pin specified by presto.h
 #define MICROPY_HW_PSRAM_CS_PIN                 PIMORONI_PRESTO_PSRAM_CS_PIN
-#define MICROPY_HW_ENABLE_PSRAM                 (1)
 
 #define MICROPY_PY_THREAD                       (0)
 #define MICROPY_GC_SPLIT_HEAP                   (0)

--- a/presto/mpconfigboard.h
+++ b/presto/mpconfigboard.h
@@ -33,6 +33,7 @@ int mp_hal_is_pin_reserved(int n);
 #define MICROPY_HW_ENABLE_PSRAM                 (1)
 
 #define MICROPY_PY_THREAD                       (0)
+#define MICROPY_GC_SPLIT_HEAP                   (0)
 
 // TODO: Remove when https://github.com/micropython/micropython/pull/15655 is merged
 #define core1_entry                             (NULL)

--- a/presto/presto.h
+++ b/presto/presto.h
@@ -120,4 +120,7 @@
 #define PICO_RP2350_A2_SUPPORTED 1
 #endif
 
+// Increase the clock divider to allow additional overclocking headroom
+#define CYW43_PIO_CLOCK_DIV_INT 4
+
 #endif


### PR DESCRIPTION
This adds full resolution support, by holding the back buffer in PSRAM.

As part of this, I've switched display update to be handled by copying back buffer to display buffer instead of flipping.  This allows for the back buffer to be in the slower PSRAM, and also makes use of PicoGraphics more intuitive (works like all other display products, instead of like PicoVision).  This also allows partial update.

This is a draft, primarily as it depends on changes to the PSRAM setup in Micropython (see separate PR), but also it doesn't quite fit - need to determine what variables we can safely move to psram_data.  There's also some corresponding changes to pimoroni-pico, currently living on https://github.com/MichaelBell/pimoroni-pico/tree/mike-dev