### PR TITLE
Free up some RAM, and go faster

### DIFF
--- a/presto/presto.h
+++ b/presto/presto.h
@@ -126,4 +126,10 @@
 // Allocate LWIP buffers in PSRAM
 #define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) __attribute__((section(".psram_data"), aligned(4))) uint8_t variable_name[LWIP_MEM_ALIGN_BUFFER(size)]
 
+// Default the system clock to 200MHz for best performance
+#define SYS_CLK_HZ           200000000
+#define PLL_SYS_VCO_FREQ_HZ 1200000000
+#define PLL_SYS_POSTDIV1    6
+#define PLL_SYS_POSTDIV2    1
+
 #endif

--- a/presto/presto.h
+++ b/presto/presto.h
@@ -123,4 +123,7 @@
 // Increase the clock divider to allow additional overclocking headroom
 #define CYW43_PIO_CLOCK_DIV_INT 3
 
+// Allocate LWIP buffers in PSRAM
+#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) __attribute__((section(".psram_data"), aligned(4))) uint8_t variable_name[LWIP_MEM_ALIGN_BUFFER(size)]
+
 #endif


### PR DESCRIPTION
Two unrelated configuration tweaks:
- Move the LWIP buffers to PSRAM.  This seems to be working reliably for me, but definitely warrants some more testing.  Providing it's stable, it gets us back to a sane amount of available internal RAM, so we shouldn't keep hitting the limit.
- Increase the default clock rate to 200MHz, which will give >60Hz refresh in both full and half res modes while not being too far above spec.