### PR TITLE
Remove arg

### DIFF
--- a/examples/image_gallery.py
+++ b/examples/image_gallery.py
@@ -201,7 +201,7 @@ def display_error(text):
         display.clear()
         display.set_pen(WHITE)
         display.text(f"Error: {text}", 10, 10, WIDTH - 10, 1)
-        presto.update(display)
+        presto.update()
         time.sleep(1)
 
 


### PR DESCRIPTION
Fixes error `TypeError: function takes 1 positional arguments but 2 were given` if an error is raised.

`display_error()` was called here because I had no SD card inserted

![image](https://github.com/user-attachments/assets/8690012f-265a-4d46-965a-0ded7e4a734a)
