### PR TITLE
Woldclock: Clear screen before network call delay

### DIFF
--- a/examples/word_clock.py
+++ b/examples/word_clock.py
@@ -9,6 +9,14 @@ from presto import Presto
 presto = Presto()
 display = presto.display
 WIDTH, HEIGHT = display.get_bounds()
+BLACK = display.create_pen(0, 0, 0)
+WHITE = display.create_pen(200, 200, 200)
+GRAY = display.create_pen(30, 30, 30)
+
+# Clear the screen before the network call is made
+display.set_pen(BLACK)
+display.clear()
+presto.update()
 
 # Length of time between updates in minutes.
 UPDATE_INTERVAL = 15
@@ -23,11 +31,6 @@ wifi = presto.connect()
 
 # Set the correct time using the NTP service.
 ntptime.settime()
-
-BLACK = display.create_pen(0, 0, 0)
-WHITE = display.create_pen(200, 200, 200)
-GRAY = display.create_pen(30, 30, 30)
-
 
 def approx_time(hours, minutes):
     nums = {0: "twelve", 1: "one", 2: "two",


### PR DESCRIPTION
If used on boot, the worldclock shows a screen of random noise for a few seconds while initialising and getting the current time.

This does a simple blanking of the screen before the network call is made making it a little cleaner.

Not sure if you want this or not though, so feel free to close if you don't.