### PR TITLE
Fix error message in image gallery

### DIFF
--- a/examples/image_gallery.py
+++ b/examples/image_gallery.py
@@ -201,7 +201,7 @@ def display_error(text):
         display.clear()
         display.set_pen(WHITE)
         display.text(f"Error: {text}", 10, 10, WIDTH - 10, 1)
-        presto.update(display)
+        presto.update()
         time.sleep(1)
 
 


### PR DESCRIPTION
Not 100% if this is correct, but when trying to run the image gallery example with the latest release, I ran into this error and looking at the other examples, none of them include the display in the `update()` call.