### PR TITLE
St7701 cached

### DIFF
--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -82,7 +82,7 @@ namespace pimoroni {
 #define TIMING_V_DISPLAY (DISPLAY_HEIGHT + TIMING_V_BACK)
 #define TIMING_V_FRONT   (5 + TIMING_V_DISPLAY)
 #define TIMING_H_FRONT   4
-#define TIMING_H_PULSE   16
+#define TIMING_H_PULSE   25
 #define TIMING_H_BACK    30
 #define TIMING_H_DISPLAY 480
 
@@ -341,12 +341,11 @@ void ST7701::start_frame_xfer()
       // TODO: Figure out what's actually display specific
       command(reg::MADCTL, 1, "\x00");  // Normal scan direction and RGB pixels
       command(reg::LNESET, 2, "\x3b\x00");   // (59 + 1) * 8 = 480 lines
-      command(reg::PORCTRL, 2, "\x0c\x01");  // Display porch settings: 12 VBP, 1 VFP
-      command(reg::INVSET, 2, "\x32\x01");      
+      command(reg::PORCTRL, 2, "\x0d\x05");  // 13 VBP, 5 VFP
+      command(reg::INVSET, 2, "\x32\x05");
       command(reg::COLCTRL, 1, "\x08");      // LED polarity reversed
       command(reg::PVGAMCTRL, 16, "\x00\x11\x18\x0e\x11\x06\x07\x08\x07\x22\x04\x12\x0f\xaa\x31\x18");
       command(reg::NVGAMCTRL, 16, "\x00\x11\x19\x0e\x12\x07\x08\x08\x08\x22\x04\x11\x11\xa9\x32\x18");
-      command(reg::RGBCTRL, 3, "\x80\x2e\x0d"); // HV mode, H and V back porch + sync
     }
 
     // Command 2 BK1 - Voltages and power and stuff

--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -77,7 +77,6 @@ namespace pimoroni {
     CND2BKxSEL = 0xFF,
   };
 
-#define DISPLAY_HEIGHT   480
 #define TIMING_V_PULSE   8
 #define TIMING_V_BACK    (5 + TIMING_V_PULSE)
 #define TIMING_V_DISPLAY (DISPLAY_HEIGHT + TIMING_V_BACK)

--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -82,7 +82,7 @@ namespace pimoroni {
 #define TIMING_V_DISPLAY (DISPLAY_HEIGHT + TIMING_V_BACK)
 #define TIMING_V_FRONT   (5 + TIMING_V_DISPLAY)
 #define TIMING_H_FRONT   4
-#define TIMING_H_PULSE   25
+#define TIMING_H_PULSE   16
 #define TIMING_H_BACK    30
 #define TIMING_H_DISPLAY 480
 
@@ -341,11 +341,12 @@ void ST7701::start_frame_xfer()
       // TODO: Figure out what's actually display specific
       command(reg::MADCTL, 1, "\x00");  // Normal scan direction and RGB pixels
       command(reg::LNESET, 2, "\x3b\x00");   // (59 + 1) * 8 = 480 lines
-      command(reg::PORCTRL, 2, "\x0d\x05");  // 13 VBP, 5 VFP
-      command(reg::INVSET, 2, "\x32\x05");
+      command(reg::PORCTRL, 2, "\x0d\x02");  // Display porch settings: 13 VBP, 2 VFP (these should not be changed)
+      command(reg::INVSET, 2, "\x31\x01");
       command(reg::COLCTRL, 1, "\x08");      // LED polarity reversed
       command(reg::PVGAMCTRL, 16, "\x00\x11\x18\x0e\x11\x06\x07\x08\x07\x22\x04\x12\x0f\xaa\x31\x18");
       command(reg::NVGAMCTRL, 16, "\x00\x11\x19\x0e\x12\x07\x08\x08\x08\x22\x04\x11\x11\xa9\x32\x18");
+      command(reg::RGBCTRL, 3, "\x80\x2e\x0e");  // HV mode, H and V back porch + sync
     }
 
     // Command 2 BK1 - Voltages and power and stuff
@@ -377,10 +378,13 @@ void ST7701::start_frame_xfer()
     command(0xEC, 2, "\x3c\x00");
     command(0xED, 16, "\xab\x89\x76\x54\x02\xff\xff\xff\xff\xff\xff\x20\x45\x67\x98\xba");
     command(0x36, 1, "\x00");
-    // End Forbidden Knowledge
 
     // Command 2 BK3
     command(reg::CND2BKxSEL, 5, "\x77\x01\x00\x00\x13");
+    command(0xE5, 1, "\xe4");
+    // End Forbidden Knowledge
+
+    command(reg::CND2BKxSEL, 5, "\x77\x01\x00\x00\x00");
     //command(reg::COLMOD, 1, "\x77");  // 24 bits per pixel...
     command(reg::COLMOD, 1, "\x66");    // 18 bits per pixel...
     //command(reg::COLMOD, 1, "\x55");  // 16 bits per pixel...

--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -83,7 +83,7 @@ namespace pimoroni {
 #define TIMING_V_DISPLAY (DISPLAY_HEIGHT + TIMING_V_BACK)
 #define TIMING_V_FRONT   (5 + TIMING_V_DISPLAY)
 #define TIMING_H_FRONT   4
-#define TIMING_H_PULSE   25
+#define TIMING_H_PULSE   16
 #define TIMING_H_BACK    30
 #define TIMING_H_DISPLAY 480
 
@@ -342,11 +342,12 @@ void ST7701::start_frame_xfer()
       // TODO: Figure out what's actually display specific
       command(reg::MADCTL, 1, "\x00");  // Normal scan direction and RGB pixels
       command(reg::LNESET, 2, "\x3b\x00");   // (59 + 1) * 8 = 480 lines
-      command(reg::PORCTRL, 2, "\x0d\x05");  // 13 VBP, 5 VFP
-      command(reg::INVSET, 2, "\x32\x05");
+      command(reg::PORCTRL, 2, "\x0c\x01");  // Display porch settings: 12 VBP, 1 VFP
+      command(reg::INVSET, 2, "\x32\x01");      
       command(reg::COLCTRL, 1, "\x08");      // LED polarity reversed
       command(reg::PVGAMCTRL, 16, "\x00\x11\x18\x0e\x11\x06\x07\x08\x07\x22\x04\x12\x0f\xaa\x31\x18");
       command(reg::NVGAMCTRL, 16, "\x00\x11\x19\x0e\x12\x07\x08\x08\x08\x22\x04\x11\x11\xa9\x32\x18");
+      command(reg::RGBCTRL, 3, "\x80\x2e\x0d"); // HV mode, H and V back porch + sync
     }
 
     // Command 2 BK1 - Voltages and power and stuff

--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -13,6 +13,8 @@
 #include <algorithm>
 #include <cstring>
 
+#define DISPLAY_HEIGHT   480
+
 namespace pimoroni {
 
   class ST7701 : public DisplayDriver {
@@ -30,7 +32,6 @@ namespace pimoroni {
     uint lcd_bl;
     uint parallel_sm;
     uint timing_sm;
-    PIO st_pio;
     uint parallel_offset;
     uint timing_offset;
     uint st_dma;
@@ -66,6 +67,18 @@ namespace pimoroni {
     void drive_timing();
     void handle_end_of_line();
 
+  protected:
+    virtual void start_line_xfer();
+    virtual void start_frame_xfer();
+
+    PIO st_pio;
+    int display_row = 0;
+    uint16_t* next_line_addr;
+    uint16_t* framebuffer;
+    uint16_t* next_framebuffer = nullptr;
+    int row_shift = 0;
+
+
   private:
     void common_init();
     void configure_display(Rotation rotate);
@@ -73,20 +86,11 @@ namespace pimoroni {
     void write_blocking_parallel(const uint8_t *src, size_t len);
     void command(uint8_t command, size_t len = 0, const char *data = NULL);
 
-    void start_line_xfer();
-    void start_frame_xfer();
-
     // Timing status
     uint16_t timing_row = 0;
     uint16_t timing_phase = 0;
     volatile bool waiting_for_vsync = false;
 
-    uint16_t* framebuffer;
-    uint16_t* next_framebuffer = nullptr;
-
-    uint16_t* next_line_addr;
-    int display_row = 0;
-    int row_shift = 0;
     int fill_row = 0;
   };
 

--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -30,11 +30,8 @@ namespace pimoroni {
     uint spi_sck;
     uint spi_dat;
     uint lcd_bl;
-    uint parallel_sm;
     uint timing_sm;
-    uint parallel_offset;
     uint timing_offset;
-    uint st_dma;
     uint st_dma2;
 
     uint d0 = 1; // First pin of 18-bit parallel interface
@@ -68,15 +65,18 @@ namespace pimoroni {
     void handle_end_of_line();
 
   protected:
-    virtual void start_line_xfer();
-    virtual void start_frame_xfer();
-
     PIO st_pio;
     int display_row = 0;
     uint16_t* next_line_addr;
     uint16_t* framebuffer;
     uint16_t* next_framebuffer = nullptr;
     int row_shift = 0;
+
+    uint st_dma;
+    uint parallel_sm;
+    uint parallel_offset;
+
+    volatile bool waiting_for_vsync = false;
 
 
   private:
@@ -86,10 +86,12 @@ namespace pimoroni {
     void write_blocking_parallel(const uint8_t *src, size_t len);
     void command(uint8_t command, size_t len = 0, const char *data = NULL);
 
+    virtual void start_line_xfer();
+    virtual void start_frame_xfer();
+
     // Timing status
     uint16_t timing_row = 0;
     uint16_t timing_phase = 0;
-    volatile bool waiting_for_vsync = false;
 
     int fill_row = 0;
   };

--- a/drivers/st7701/st7701Cached.cpp
+++ b/drivers/st7701/st7701Cached.cpp
@@ -48,7 +48,6 @@ namespace pimoroni {
 
     if (display_row > DISPLAY_HEIGHT) {
       next_line_addr = 0;
-      AddTiming(1);
     }
     else {
       next_line_addr = &framebuffer[width * ((display_row%cachelines) >> row_shift)];
@@ -57,23 +56,8 @@ namespace pimoroni {
       int cache_line  = update_row % cachelines;
       next_next_line_addr = &framebuffer[width * (cache_line >> row_shift)];
 
-      AddTiming(1);
-
       pSrc = &backbuffer[width * (update_row >> row_shift)];
       memcpy(next_next_line_addr, (void *) pSrc, width * 2);
-
-#if DIRECT_TEST
-      if(update_row == 0) {
-        memset(next_next_line_addr+50, 0xff, 100);
-      }
-      else if(update_row == 479) {
-        memset(next_next_line_addr+50, 0xff, 100);
-      }
-      else 
-      {
-        memset(next_next_line_addr+50, 0x22, 100);
-      }
-#endif
     }
   }
 
@@ -104,9 +88,7 @@ namespace pimoroni {
     pio_sm_set_enabled(st_pio, parallel_sm, true);
     display_row = 0;
     next_line_addr = framebuffer;
-    AddTiming(0);
 
-    //memcpy(framebuffer, backbuffer, width * 2);
     dma_channel_set_read_addr(st_dma, framebuffer, true);  
     waiting_for_vsync = false;
     __sev();

--- a/drivers/st7701/st7701Cached.cpp
+++ b/drivers/st7701/st7701Cached.cpp
@@ -1,0 +1,70 @@
+#include "st7701Cached.hpp"
+
+namespace pimoroni {
+
+  ST7701Cached::ST7701Cached(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, 
+                            uint16_t cachelines, uint16_t* framecache, uint16_t* backbuffer,
+                            uint d0, uint hsync, uint vsync, uint lcd_de, uint lcd_dot_clk)
+  : ST7701(width, height, rotation, control_pins, framecache, d0, hsync, vsync, lcd_de, lcd_dot_clk),
+    cachelines(cachelines),
+    backbuffer(backbuffer)
+  {
+
+  }
+
+  void ST7701Cached::update(PicoGraphics *graphics) 
+  {
+  }
+      
+  void ST7701Cached::partial_update(PicoGraphics *display, Rect region) 
+  {
+  }
+
+  // TODO: avoid that 4 line hack for start of frame and do properly
+  void ST7701Cached::start_line_xfer() 
+  {
+    hw_clear_bits(&st_pio->irq, 0x1);
+
+    uint16_t *pSrc;
+    uint16_t *pDst;
+    
+    ++display_row;
+
+    if (display_row == DISPLAY_HEIGHT) 
+    {
+      // TODO properly
+      next_line_addr = framebuffer;
+    }
+    else 
+    {
+      next_line_addr = &framebuffer[width * ((display_row%cachelines) >> row_shift)];
+
+      // simple test render next line
+      if(display_row < DISPLAY_HEIGHT-1)
+      {
+        pSrc = &backbuffer[width * (display_row >> row_shift)];
+        pDst = &framebuffer[width * (((display_row+1)%cachelines) >> row_shift)];;
+        memcpy(pDst, pSrc, width*2);
+        //memset(pDst, display_row, width * 4);
+      }
+      else
+      {
+        // TODO properly
+        pSrc = backbuffer;
+        pDst = framebuffer;
+        memcpy(pDst, pSrc, width*4);
+        //memset(pDst, 0xff, width * 4);
+      }
+    }
+  }
+
+  void ST7701Cached::start_frame_xfer()
+  {
+    if (next_backbuffer) {
+      backbuffer = next_backbuffer;
+      next_backbuffer = nullptr;
+    }
+
+    ST7701::start_frame_xfer();
+  }
+}

--- a/drivers/st7701/st7701Cached.cpp
+++ b/drivers/st7701/st7701Cached.cpp
@@ -29,40 +29,80 @@ namespace pimoroni {
 
   void ST7701Cached::start_line_xfer() 
   {
-    AddTiming(1);
 
     hw_clear_bits(&st_pio->irq, 0x1);
 
-    uint16_t *pSrc;
-    uint16_t *pDst;
-    
+    volatile uint16_t *pSrc;
+    volatile uint16_t *pDst;
+    volatile static uint8_t uEnd = 40;
+
     ++display_row;
 
-    if (display_row > DISPLAY_HEIGHT) 
+    // PIO displaying display_row
+    // we copy to display_row+1
+
+    if (display_row >= DISPLAY_HEIGHT) // 480 and 481
     {
-      // TODO properly
       next_line_addr = 0;
+      AddTiming(1);
     }
     else 
     {
       next_line_addr = &framebuffer[width * ((display_row%cachelines) >> row_shift)];
+      int update_line;
 
-      // simple test render next line
-      if(display_row < DISPLAY_HEIGHT)
-      {
-        pSrc = &backbuffer[width * ((display_row + OFFSET) >> row_shift)];
-        pDst = &framebuffer[width * (((display_row + OFFSET) % cachelines) >> row_shift)];;
-        memcpy(pDst, pSrc, width*2);
-        //memset(pDst, display_row, width * 4);
+      if(display_row < DISPLAY_HEIGHT-2){
+        update_line = display_row + 1;
       }
-      else
-      {
-        // first line
-        pSrc = backbuffer;
-        pDst = &framebuffer[width * (((display_row + OFFSET) % cachelines) >> row_shift)];;
-        memcpy(pDst, pSrc, width*2);
-        //memset(pDst, 0x44, width * 2);
+      else {
+        update_line = (display_row -(DISPLAY_HEIGHT - 2));
       }
+
+      next_next_line_addr = &framebuffer[width * ((update_line % cachelines) >> row_shift)];
+      AddTiming(1);
+
+      memset(next_next_line_addr, 0x00, width*2);
+      if(display_row < DISPLAY_HEIGHT-3) // 1 - 476 = 475 rows!!!!
+      {
+        memset(next_next_line_addr, 0x22, display_row); 
+      }
+      else if(display_row < DISPLAY_HEIGHT-2) // last row 477
+      {
+        memset(next_next_line_addr, 0xff, 960);
+      }
+      else if(display_row < DISPLAY_HEIGHT-1) // 478
+      {
+        memset(next_next_line_addr, 0xff, 200); // line 1
+      }
+      else if(display_row < DISPLAY_HEIGHT) // 479
+      {
+        memset(next_next_line_addr, 0xff, 400); // line 2
+      }
+      else if(display_row < DISPLAY_HEIGHT+1) // 480
+      {
+        memset(next_next_line_addr, 0xff, 400); // not seen
+      }
+      else if(display_row < DISPLAY_HEIGHT+2) // 481
+      {
+        memset(next_next_line_addr, 0xff, 960); // not seend
+      }
+
+      // // simple test render next line
+      // if(display_row < DISPLAY_HEIGHT)
+      // {
+      //   pSrc = &backbuffer[width * ((display_row + OFFSET) >> row_shift)];
+      //   pDst = &framebuffer[width * (((display_row + OFFSET) % cachelines) >> row_shift)];;
+      //   memcpy((void *)pDst, (void *)pSrc, width*2);
+      //   //memset(pDst, display_row, width * 4);
+      // }
+      // else
+      // {
+      //   // first line
+      //   pSrc = backbuffer;
+      //   pDst = &framebuffer[width * (((display_row + OFFSET) % cachelines) >> row_shift)];;
+      //   memcpy((void *)pDst, (void *)pSrc, width*2);
+      //   //memset(pDst, 0x44, width * 2);
+      // }
 
       // else if(display_row < DISPLAY_HEIGHT)
       // {
@@ -90,6 +130,7 @@ namespace pimoroni {
 
   void ST7701Cached::start_frame_xfer()
   {
+    display_row = 0;
     AddTiming(0);
 
     hw_clear_bits(&st_pio->irq, 0x2);

--- a/drivers/st7701/st7701Cached.cpp
+++ b/drivers/st7701/st7701Cached.cpp
@@ -11,9 +11,17 @@ namespace pimoroni {
     cachelines(cachelines),
     backbuffer(backbuffer)
   {
-
   }
 
+
+  ST7701Cached::ST7701Cached(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, uint16_t* backbuffer,
+                            uint d0, uint hsync, uint vsync, uint lcd_de, uint lcd_dot_clk)
+  : ST7701(width, height, rotation, control_pins, nullptr, d0, hsync, vsync, lcd_de, lcd_dot_clk),
+    backbuffer(backbuffer)
+  {
+    cachelines = 3;
+    framebuffer = (uint16_t *)malloc(width * 2 * cachelines);
+  }
 
   void ST7701Cached::update(PicoGraphics *graphics) 
   {

--- a/drivers/st7701/st7701Cached.cpp
+++ b/drivers/st7701/st7701Cached.cpp
@@ -19,8 +19,10 @@ namespace pimoroni {
   : ST7701(width, height, rotation, control_pins, nullptr, d0, hsync, vsync, lcd_de, lcd_dot_clk),
     backbuffer(backbuffer)
   {
-    cachelines = 3;
-    framebuffer = (uint16_t *)malloc(width * 2 * cachelines);
+    // the cache needs to be 6 lines for height 240 and 3 lines for height 480
+    // memory usage stays the same.
+    cachelines = (height == 480) ? 3 : 6;
+    framebuffer = (uint16_t *)malloc(DISPLAY_HEIGHT * 2 * cachelines);
   }
 
   void ST7701Cached::update(PicoGraphics *graphics) 

--- a/drivers/st7701/st7701Cached.hpp
+++ b/drivers/st7701/st7701Cached.hpp
@@ -3,13 +3,31 @@
 #include "st7701.hpp"
 
 namespace pimoroni {
+    #define TIMINGS_COUNT (481*10)
+    typedef struct 
+    {
+      uint8_t  type;
+      uint64_t time;
+    } Timing;
 
   class ST7701Cached : public ST7701 {
+
 
   private:
     uint16_t* backbuffer = nullptr;
     uint16_t* next_backbuffer = nullptr;
     uint16_t  cachelines = 0;
+
+    Timing timings[TIMINGS_COUNT];
+    uint32_t nextTiming = 0;
+
+    void AddTiming(uint8_t type)
+    {
+      timings[nextTiming] = {type, time_us_64()};
+      nextTiming++;
+      if(nextTiming == TIMINGS_COUNT)
+        nextTiming = 0;
+    }
 
   public:
     // Parallel init
@@ -27,6 +45,7 @@ namespace pimoroni {
   private:
     void start_line_xfer() override;
     void start_frame_xfer() override;
+
   };
 
 }

--- a/drivers/st7701/st7701Cached.hpp
+++ b/drivers/st7701/st7701Cached.hpp
@@ -45,6 +45,9 @@ namespace pimoroni {
                  uint16_t cache_lines, uint16_t* framecache, uint16_t* backbuffer,
                  uint d0=1, uint hsync=19, uint vsync=20, uint lcd_de = 21, uint lcd_dot_clk = 22);
 
+    ST7701Cached(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, uint16_t* backbuffer,
+                 uint d0=1, uint hsync=19, uint vsync=20, uint lcd_de = 21, uint lcd_dot_clk = 22);
+
     void update(PicoGraphics *graphics) override;
     void partial_update(PicoGraphics *display, Rect region) override;
 

--- a/drivers/st7701/st7701Cached.hpp
+++ b/drivers/st7701/st7701Cached.hpp
@@ -7,7 +7,11 @@ namespace pimoroni {
     typedef struct 
     {
       uint8_t  type;
+      uint16_t *daddr;
+      uint16_t *uaddr;
       uint64_t time;
+      uint16_t interval;
+      uint16_t line;
     } Timing;
 
   class ST7701Cached : public ST7701 {
@@ -23,7 +27,13 @@ namespace pimoroni {
 
     void AddTiming(uint8_t type)
     {
-      timings[nextTiming] = {type, time_us_64()};
+      uint64_t interval;
+      if(nextTiming == 0)
+        interval = time_us_64() - timings[TIMINGS_COUNT-1].time;
+      else
+        interval = time_us_64() - timings[nextTiming-1].time;
+
+      timings[nextTiming] = {type, next_line_addr, next_next_line_addr, time_us_64(), interval, (uint16_t)display_row};
       nextTiming++;
       if(nextTiming == TIMINGS_COUNT)
         nextTiming = 0;
@@ -46,6 +56,7 @@ namespace pimoroni {
     void start_line_xfer() override;
     void start_frame_xfer() override;
 
+    uint16_t *next_next_line_addr;
   };
 
 }

--- a/drivers/st7701/st7701Cached.hpp
+++ b/drivers/st7701/st7701Cached.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "st7701.hpp"
+
+namespace pimoroni {
+
+  class ST7701Cached : public ST7701 {
+
+  private:
+    uint16_t* backbuffer = nullptr;
+    uint16_t* next_backbuffer = nullptr;
+    uint16_t  cachelines = 0;
+
+  public:
+    // Parallel init
+    ST7701Cached(uint16_t width, uint16_t height, Rotation rotation, SPIPins control_pins, 
+                 uint16_t cache_lines, uint16_t* framecache, uint16_t* backbuffer,
+                 uint d0=1, uint hsync=19, uint vsync=20, uint lcd_de = 21, uint lcd_dot_clk = 22);
+
+    void update(PicoGraphics *graphics) override;
+    void partial_update(PicoGraphics *display, Rect region) override;
+
+    void set_backbuffer(uint16_t* next_fb) {
+      next_backbuffer = next_fb;
+    }
+    
+  private:
+    void start_line_xfer() override;
+    void start_frame_xfer() override;
+  };
+
+}

--- a/drivers/st7701/st7701Cached.hpp
+++ b/drivers/st7701/st7701Cached.hpp
@@ -3,41 +3,12 @@
 #include "st7701.hpp"
 
 namespace pimoroni {
-    #define TIMINGS_COUNT (481*10)
-    typedef struct 
-    {
-      uint8_t  type;
-      uint16_t *daddr;
-      uint16_t *uaddr;
-      uint64_t time;
-      uint16_t interval;
-      uint16_t line;
-    } Timing;
-
   class ST7701Cached : public ST7701 {
-
 
   private:
     uint16_t* backbuffer = nullptr;
     uint16_t* next_backbuffer = nullptr;
     uint16_t  cachelines = 0;
-
-    Timing timings[TIMINGS_COUNT];
-    uint32_t nextTiming = 0;
-
-    void AddTiming(uint8_t type)
-    {
-      uint64_t interval;
-      if(nextTiming == 0)
-        interval = time_us_64() - timings[TIMINGS_COUNT-1].time;
-      else
-        interval = time_us_64() - timings[nextTiming-1].time;
-
-      timings[nextTiming] = {type, next_line_addr, next_next_line_addr, time_us_64(), interval, (uint16_t)display_row};
-      nextTiming++;
-      if(nextTiming == TIMINGS_COUNT)
-        nextTiming = 0;
-    }
 
   public:
     // Parallel init

--- a/drivers/st7701/st7701_parallel.pio
+++ b/drivers/st7701/st7701_parallel.pio
@@ -6,8 +6,8 @@
 .side_set 1
 
 .wrap_target
-  mov x, y      side 1  ; y needs to be set to (width/2)-1 at init time
-  wait 1 irq 4  side 1  ; wait for the irq from the timing SM
+  mov x, y      side 0  ; y needs to be set to (width/2)-1 at init time
+  wait 1 irq 4  side 0  ; wait for the irq from the timing SM
 loop:
   out isr, 32 side 1     
   mov pins, ::isr side 1 [1]

--- a/drivers/st7701/st7701_parallel.pio
+++ b/drivers/st7701/st7701_parallel.pio
@@ -6,8 +6,8 @@
 .side_set 1
 
 .wrap_target
-  mov x, y      side 0  ; y needs to be set to (width/2)-1 at init time
-  wait 1 irq 4  side 0  ; wait for the irq from the timing SM
+  mov x, y      side 1  ; y needs to be set to (width/2)-1 at init time
+  wait 1 irq 4  side 1  ; wait for the irq from the timing SM
 loop:
   out isr, 32 side 1     
   mov pins, ::isr side 1 [1]

--- a/drivers/st7701/st7701_presto.cmake
+++ b/drivers/st7701/st7701_presto.cmake
@@ -1,7 +1,8 @@
 add_library(st7701_presto INTERFACE)
 
 target_sources(st7701_presto INTERFACE
-  ${CMAKE_CURRENT_LIST_DIR}/st7701.cpp)
+  ${CMAKE_CURRENT_LIST_DIR}/st7701.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/st7701Cached.cpp)
 
 pico_generate_pio_header(st7701_presto ${CMAKE_CURRENT_LIST_DIR}/st7701_parallel.pio)
 pico_generate_pio_header(st7701_presto ${CMAKE_CURRENT_LIST_DIR}/st7701_timing.pio)

--- a/drivers/st7701/st7701_timing.pio
+++ b/drivers/st7701/st7701_timing.pio
@@ -15,6 +15,6 @@
   out x, 14           side 1    ; Loop count
 sync_loop:
   nop                 side 0
-  jmp x--, sync_loop  side 1
+  jmp x--, sync_loop  side 1 
   out exec, 16        side 0
 .wrap


### PR DESCRIPTION
This adds a new subclass `ST7701Cached` that uses a small cache in pico ram to drive the underlying `ST7701` class.

This allows freeing up lots of lovely pico ram but with some disadvantages:

Due to the reduced memory use the normal Update where the display is updated behind the current scanline is no longer used, so if you run with a single back buffer then you will see some flicker. You can run with two back buffers then you do have the speed of the psram to deal with when keeping them in sync.

