### PR TITLE
Removed double call to ntptime.settime

### DIFF
--- a/examples/word_clock.py
+++ b/examples/word_clock.py
@@ -29,8 +29,11 @@ words = ["it", "d", "is", "m", "about", "lv", "half", "c", "quarter", "b", "to",
 # WiFi setup
 wifi = presto.connect()
 
-# Set the correct time using the NTP service.
-ntptime.settime()
+# grab the current time from the ntp server and update the Pico RTC
+try:
+    ntptime.settime()
+except OSError:
+    print("Unable to contact NTP server")
 
 def approx_time(hours, minutes):
     nums = {0: "twelve", 1: "one", 2: "two",
@@ -54,11 +57,6 @@ def approx_time(hours, minutes):
 
 def update():
     global time_string
-    # grab the current time from the ntp server and update the Pico RTC
-    try:
-        ntptime.settime()
-    except OSError:
-        print("Unable to contact NTP server")
 
     current_t = rtc.datetime()
     time_string = approx_time(current_t[4] - 12 if current_t[4] > 12 else current_t[4], current_t[5])


### PR DESCRIPTION
Removed additional call to settime in the update function. This speeds up startup and the 2nd call was largely unnecessary (unless the RTC has some serious drift to it)