### PR TITLE
Fix brightness control

### DIFF
--- a/drivers/st7701/st7701.hpp
+++ b/drivers/st7701/st7701.hpp
@@ -47,7 +47,6 @@ namespace pimoroni {
     uint lcd_dot_clk = 22;
 
     static const uint32_t SPI_BAUD = 8'000'000;
-    static const uint32_t BACKLIGHT_PWM_TOP = 6200;
 
   public:
     // Parallel init

--- a/examples/brightness.py
+++ b/examples/brightness.py
@@ -1,0 +1,43 @@
+from presto import Presto
+from touch import Button
+from time import sleep
+
+presto = Presto()
+display = presto.display
+
+FG_COLOR = display.create_pen(0, 0, 255)
+BG_COLOR = display.create_pen(255, 255, 255)
+
+touch = presto.touch
+
+button_down = Button(10, 125, 105, 105)
+button_up = Button(125, 125, 105, 105)
+
+brightness = 100
+
+while True:
+    touch.poll()
+
+    display.set_pen(BG_COLOR)
+    display.clear()
+    
+    display.set_pen(FG_COLOR)
+    display.text("brightness: " + str(brightness)+ " %", 10, 10)
+
+    display.rectangle(*button_down.bounds)
+    display.rectangle(*button_up.bounds)
+
+    if button_down.is_pressed():
+        brightness -= 1
+        if brightness < 0: brightness = 0
+
+    if button_up.is_pressed():
+        brightness += 1
+        if brightness > 100: brightness = 100
+        
+    presto.set_backlight(brightness / 100)
+    
+    presto.update()
+    sleep(0.02)
+
+


### PR DESCRIPTION
The CTRL pin of the AP3031 is picky regarding the applied PWM frequency. If the frequency is too high, the dimming of the display backlight behaves strangely.

I have achieved the best results and seamless dimming between 0% and 100% with a PWM frequency of about 100Hz. Therefore, a corresponding clkdiv is set in this patch.