### PR TITLE
word_clock.py: fix hour showing incorrectly when minutes zero

### DIFF
--- a/examples/word_clock.py
+++ b/examples/word_clock.py
@@ -66,7 +66,7 @@ def approx_time(hours, minutes):
 
     if hours == 12:
         hours = 0
-    if minutes > 0 and minutes < 8:
+    if minutes >= 0 and minutes < 8:
         return "it is about " + nums[hours] + " O'Clock"
     elif minutes >= 8 and minutes < 23:
         return "it is about quarter past " + nums[hours]


### PR DESCRIPTION
Fixes an issue that caused the hour to display incorrectly when the minutes were at :00.

This resolves #93 and PR #28 