### PR TITLE
ST7701: fix permanent stall in start_frame_xfer() when TX FIFO is empty (blank panel in C++ builds)

### DIFF
--- a/drivers/st7701/st7701.cpp
+++ b/drivers/st7701/st7701.cpp
@@ -187,13 +187,21 @@ void __not_in_flash_func(ST7701::start_frame_xfer)()
     dma_channel_wait_for_finish_blocking(st_dma);
     pio_sm_set_enabled(st_pio, parallel_sm, false);
     pio_sm_clear_fifos(st_pio, parallel_sm);
-    pio_sm_exec_wait_blocking(st_pio, parallel_sm, pio_encode_mov(pio_osr, pio_null));
-    pio_sm_exec_wait_blocking(st_pio, parallel_sm, pio_encode_out(pio_null, 32));
-    pio_sm_exec_wait_blocking(st_pio, parallel_sm, pio_encode_jmp(parallel_offset));
+    // Reset the SM for the new frame. The original code exec'd
+    //   mov osr,null / out null,32 / jmp
+    // with pio_sm_exec_wait_blocking to leave the OSR empty, but with the TX
+    // FIFO empty (DMA not yet armed, e.g. on the very first frame) the exec'd
+    // `out` latches EXEC_STALLED forever and this ISR spins, freezing the
+    // core that services the display (blank panel).
+    // pio_sm_restart() empties the OSR/ISR without any stallable exec
+    // (X/Y survive, so the width loop counter in Y is preserved), and a
+    // `jmp` can never stall so it needs no blocking wait.
+    pio_sm_restart(st_pio, parallel_sm);
+    pio_sm_exec(st_pio, parallel_sm, pio_encode_jmp(parallel_offset));
     pio_sm_set_enabled(st_pio, parallel_sm, true);
     display_row = 0;
     next_line_addr = framebuffer;
-    dma_channel_set_read_addr(st_dma, framebuffer, true);  
+    dma_channel_set_read_addr(st_dma, framebuffer, true);
 
     waiting_for_vsync = false;
     __sev();


### PR DESCRIPTION
Fixes #112.

`start_frame_xfer()` resets the parallel SM between frames by exec'ing `mov osr,null` / `out null,32` / `jmp` via `pio_sm_exec_wait_blocking()`. The SM uses autopull, so when the TX FIFO is empty the exec'd `out` triggers an autopull that can never complete — the instruction latches `EXEC_STALLED` and `pio_sm_exec_wait_blocking()` spins forever **inside the end-of-line ISR**, freezing the core that services the display. The FIFO is empty by construction on the very first frame boundary (the FIFOs were just cleared and the pixel DMA is only armed at the end of this function), so pico-sdk C++ users of the RGB565 path get a reliably blank panel.

This replaces the exec dance with `pio_sm_restart()`, which empties the OSR/ISR shift counters (forcing a fresh autopull on resume) without executing anything stallable, and preserves X/Y — so the line-width loop counter in Y set at init survives. The `jmp` to the program start cannot stall and doesn't need a blocking wait.

**Tested on hardware** (Presto, RP2350B, pico-sdk 2.3.0): RGB565 240×240 non-palette path, boilerplate-style usage; previously froze deterministically at the first frame boundary (verified with stage markers in the ISR + a heartbeat counter on the display core), now scans at ~60fps and has been running an LVGL app on top without issue. Diagnostic details and PIO/DMA state captures are in #112.

The palette path shares this function; the same reasoning applies (restart leaves the palette SM's feed state governed by its own DMA chain), but I've only been able to hardware-test the non-palette path.
